### PR TITLE
Added setup task to copy database.yml

### DIFF
--- a/db/schema.rb
+++ b/db/schema.rb
@@ -61,10 +61,12 @@ ActiveRecord::Schema.define(:version => 20101207145753) do
     t.string   "reset_password_token"
     t.string   "remember_token"
     t.datetime "remember_created_at"
+    t.string   "confirmation_token"
     t.boolean  "is_admin"
     t.datetime "deleted_at"
   end
 
+  add_index "members", ["confirmation_token"], :name => "index_members_on_confirmation_token", :unique => true
   add_index "members", ["email"], :name => "index_members_on_email", :unique => true
   add_index "members", ["reset_password_token"], :name => "index_members_on_reset_password_token", :unique => true
 

--- a/lib/tasks/setup.rake
+++ b/lib/tasks/setup.rake
@@ -1,14 +1,20 @@
 desc "Sets up the application for development"
 task :setup =>  [
-                  "setup:bundle", # Bundler, keep this first
-                  "doc:app",      # YARD docs
-                  "setup:intro"   # tl;dr, keep this last
+                  "setup:bundle",              # Bundler, keep this first
+                  "setup:copy_default_config", # Create database.yml
+                  "doc:app",                   # YARD docs
+                  "setup:intro"                # tl;dr, keep this last
                 ]
 
 namespace :setup do
   desc "Installs required gems"
   task :bundle do
     system %{bundle}
+  end
+
+  desc "Copies default database.yml into place"
+  task :copy_default_config do
+    cp "config/database.yml.example", "config/database.yml"
   end
 
   desc "Hello, my name is ________"


### PR DESCRIPTION
Very, very tiny change: for convenience `rake setup` now copies database.yml.example into place. I also included a commit that updates @db/schema.rb@ with the latest migrations.
