### PR TITLE
Improvements to motion_spec

### DIFF
--- a/db/schema.rb
+++ b/db/schema.rb
@@ -61,10 +61,12 @@ ActiveRecord::Schema.define(:version => 20101207145753) do
     t.string   "reset_password_token"
     t.string   "remember_token"
     t.datetime "remember_created_at"
+    t.string   "confirmation_token"
     t.boolean  "is_admin"
     t.datetime "deleted_at"
   end
 
+  add_index "members", ["confirmation_token"], :name => "index_members_on_confirmation_token", :unique => true
   add_index "members", ["email"], :name => "index_members_on_email", :unique => true
   add_index "members", ["reset_password_token"], :name => "index_members_on_reset_password_token", :unique => true
 

--- a/lib/tasks/setup.rake
+++ b/lib/tasks/setup.rake
@@ -1,14 +1,20 @@
 desc "Sets up the application for development"
 task :setup =>  [
-                  "setup:bundle", # Bundler, keep this first
-                  "doc:app",      # YARD docs
-                  "setup:intro"   # tl;dr, keep this last
+                  "setup:bundle",              # Bundler, keep this first
+                  "setup:copy_default_config", # Create database.yml
+                  "doc:app",                   # YARD docs
+                  "setup:intro"                # tl;dr, keep this last
                 ]
 
 namespace :setup do
   desc "Installs required gems"
   task :bundle do
     system %{bundle}
+  end
+
+  desc "Copies default database.yml into place"
+  task :copy_default_config do
+    cp "config/database.yml.example", "config/database.yml"
   end
 
   desc "Hello, my name is ________"

--- a/spec/models/motion_spec.rb
+++ b/spec/models/motion_spec.rb
@@ -131,4 +131,26 @@ describe Motion do
       end
     end
   end
+  
+  describe 'schedule_updates' do
+    describe "when a motion is created" do
+      it "should ask the MotionState to schedule updates" do
+        @motion.state.should_receive(:schedule_updates)
+        @motion.save
+      end
+    end
+    
+    describe "when a motion is saved with a state change" do
+      it "should ask the MotionState to schedule updates" do
+        @motion.state_name = "waitingsecond"
+        @motion.save
+        
+        @motion.state_name = "discussing"
+        
+        @motion.state.should_receive(:schedule_updates)
+        @motion.save
+      end
+    end
+  end
+  
 end

--- a/spec/models/motion_spec.rb
+++ b/spec/models/motion_spec.rb
@@ -2,8 +2,7 @@ require 'spec_helper'
 
 describe Motion do
   before do
-    @motion = Factory.create(:motion)
-    @member = Factory.create(:active_membership).member
+    @motion = Factory.build(:motion)
   end
 
   it "knows how many yea votes have been cast for the motion" do
@@ -82,24 +81,31 @@ describe Motion do
 
     describe "vote" do
       it "creates a new vote with the given member and value" do
-        @motion.vote(@member, true)
-        Event.votes.last.member.should eql @member
+        current_motion = Factory.create(:motion)
+        voting_member  = Factory.create(:active_membership).member
+        
+        current_motion.vote(voting_member, true)
+        Event.votes.last.member.should eql voting_member
         Event.votes.last.value.should be_true
       end
     end
 
     describe 'second(member)' do
       it "creates a new second for the member" do
+        current_motion   = Factory.create(:motion)
+        seconding_member = Factory.create(:active_membership).member
+        
         lambda do
-          @motion.second(@member)
-        end.should change { @motion.seconds.count }
+          current_motion.second(seconding_member)
+        end.should change { current_motion.seconds.count }
       end
     end
   end
 
   describe 'conflicts_with_member?' do
     before :each do
-      @conflict = Factory(:conflict)
+      @member   = Factory.build(:active_membership).member
+      @conflict = Factory.build(:conflict)
     end
 
     describe "when a member has a conflict unrelated to this motion" do


### PR DESCRIPTION
In preparation for some work I'm about to start on the e-mail notification stories, I made a couple of small improvements to motion_spec:
1. The before(:each) block at the top of the file (that runs before every test) now only builds Motion objects instead of always saving them to the database. Examples that need a saved record can create their own object, or just run `@motion.save`.
2. I've added some examples covering the `schedule_updates` callback that runs on create or state change.
