### PR TITLE
Initial work on e-mail notifications

### DIFF
--- a/app/mailers/notifications.rb
+++ b/app/mailers/notifications.rb
@@ -15,4 +15,19 @@ class Notifications < ActionMailer::Base
     mail :to      => member.email,
          :subject => subject_text
   end
+
+  # Notifies a member via e-mail when a motion's state changes
+  #   @param [Symbol] to_state The state change being performed
+  #   @param [Motion] motion The motion being changed
+  #   @param [Member] member The member receiving the e-mail notification
+  #   @return [Mail::Message] The generated e-mail object
+  def motion_state_changed(motion, member)
+    @motion = motion
+    @member = member
+
+    subject_text = I18n.t("notifications.motion_state_changed.subjects.#{motion.state_name}") + ": #{motion.title}"
+
+    mail :to      => member.email,
+         :subject => subject_text
+  end
 end

--- a/app/models/motion.rb
+++ b/app/models/motion.rb
@@ -31,6 +31,7 @@ class Motion < ActiveRecord::Base
   after_create :schedule_updates
 
   after_create :send_email_on_create
+  after_save :send_email_on_state_change, :if => :state_name_changed?
 
   after_initialize :assign_state
 
@@ -206,6 +207,12 @@ private
   def send_email_on_create
     ActiveMembership.members_active_at(Time.now).each do |member|
       Notifications.motion_created(self, member).deliver
+    end
+  end
+
+  def send_email_on_state_change
+    ActiveMembership.members_active_at(Time.now).each do |member|
+      Notifications.motion_state_changed(self, member).deliver
     end
   end
 

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -5,7 +5,11 @@ en:
   hello: "Hello world"
   notifications:
     motion_created:
-      subject: "NEW MOTION"
+      subject: "New motion"
+    motion_state_changed:
+      subjects:
+        discussing: "Motion seconded"
+        voting: "Motion now voting"
   admin:
     members:
       titles:

--- a/spec/mailers/notifications_spec.rb
+++ b/spec/mailers/notifications_spec.rb
@@ -26,4 +26,28 @@ describe Notifications do
     end
   end
 
+  describe "motion state changed" do
+    before do
+      @motion = Factory.stub(:motion, :state_name => "discussing")
+      @member = Factory.stub(:member, :email => "member@email.com")
+    end
+
+    it "should be sent to the specified member" do
+      mail = Notifications.motion_state_changed(@motion, @member)
+      mail.to.should == [@member.email]
+    end
+
+    describe "subject line" do
+      it "should include the motion's title" do
+        mail = Notifications.motion_state_changed(@motion, @member)
+        mail.subject.should include(@motion.title)
+      end
+
+      it "should say a motion was created" do
+        mail = Notifications.motion_state_changed(@motion, @member)
+        mail.subject.should include(I18n.t("notifications.motion_state_changed.subjects.discussing"))
+      end
+    end
+  end
+
 end

--- a/spec/models/motion_spec.rb
+++ b/spec/models/motion_spec.rb
@@ -179,6 +179,31 @@ describe Motion do
         @motion.save
       end
     end
+    
+    describe "when a motion enters the discussion state" do
+      # state_name == voting
+      it "should send a notification to all members"
+    end
+    
+    describe "when a motion enters the voting state" do
+      # state_name == voting
+      it "should send a notification to all members"
+    end
+    
+    describe "when a motion fails to reach the voting state" do
+      # state_name == closed && failed?
+      it "should send a notification to all members"
+    end
+    
+    describe "when a motion passes" do
+      # state_name == closed && passed?
+      it "should send a notification to all members"
+    end
+    
+    describe "when a motion fails" do
+      # state_name == closed && failed?
+      it "should send a notification to all members"
+    end
   end
 
 end

--- a/spec/models/motion_spec.rb
+++ b/spec/models/motion_spec.rb
@@ -4,7 +4,7 @@ describe Motion do
   before do
     RSpec::Mocks::setup(self)
 
-    @motion = Factory.build(:motion)
+    @motion = Factory.stub(:motion)
   end
 
   describe "vote counting", :database => true do
@@ -143,6 +143,7 @@ describe Motion do
   describe 'schedule_updates', :database => true do
     describe "when a motion is created" do
       it "should ask the MotionState to schedule updates" do
+        @motion = Factory.build(:motion)
         @motion.state.should_receive(:schedule_updates)
         @motion.save
       end
@@ -150,11 +151,8 @@ describe Motion do
 
     describe "when a motion is saved with a state change" do
       it "should ask the MotionState to schedule updates" do
-        @motion.state_name = "waitingsecond"
-        @motion.save
-
+        @motion = Factory.create(:motion)
         @motion.state_name = "discussing"
-
         @motion.state.should_receive(:schedule_updates)
         @motion.save
       end

--- a/spec/models/motion_spec.rb
+++ b/spec/models/motion_spec.rb
@@ -171,12 +171,8 @@ describe Motion do
       end
 
       it "should send a notification to all members" do
-        mock_mail = mock('mock mail', :deliver => true)
-
-        Notifications.should_receive(:motion_created).with(@motion, @member_1).and_return(mock_mail)
-        Notifications.should_receive(:motion_created).with(@motion, @member_2).and_return(mock_mail)
-
         @motion.save
+        ActionMailer::Base.deliveries.should have(2).emails
       end
     end
     

--- a/spec/models/motion_spec.rb
+++ b/spec/models/motion_spec.rb
@@ -199,11 +199,12 @@ describe Motion do
         sample_message = ActionMailer::Base.deliveries.first
         sample_message.subject.should include(I18n.t('notifications.motion_state_changed.subjects.discussing'))
       end
-    end
 
-    describe "when a motion enters the voting state" do
-      # state_name == voting
-      it "should send a notification to all members"
+      it "should notify members the motion has entered voting" do
+        @motion.voting!
+        sample_message = ActionMailer::Base.deliveries.first
+        sample_message.subject.should include(I18n.t('notifications.motion_state_changed.subjects.voting'))
+      end
     end
 
     describe "when a motion passes" do

--- a/spec/models/motion_spec.rb
+++ b/spec/models/motion_spec.rb
@@ -140,7 +140,11 @@ describe Motion do
     end
   end
 
-  describe 'schedule_updates', :database => true do
+  describe 'schedule_updates' do
+    before(:each) do
+      ActiveRecord::Base.connection.stub(:execute)
+    end
+
     describe "when a motion is created" do
       it "should ask the MotionState to schedule updates" do
         @motion = Factory.build(:motion)
@@ -159,11 +163,13 @@ describe Motion do
     end
   end
 
-  describe "email notifications", :database => true do
+  describe "email notifications" do
     before(:each) do
+      # Disable database hits for speed, we're only interested in whether the callbacks fire
+      ActiveRecord::Base.connection.stub(:execute)
+
       @member_1 = Factory.stub(:member, :email => "member1@email.com")
       @member_2 = Factory.stub(:member, :email => "member2@email.com")
-
       ActiveMembership.stub(:members_active_at).and_return([@member_1, @member_2])
     end
 


### PR DESCRIPTION
The Motion model now sends emails to all members when:
- A motion is created
- A motion's state changes

The subject lines for the various e-mails have a prefix set via I18n, e.g. the notification that's sent when a motion enters the 'discussing' state has a subject line prepended with the localized string 'notifications.motion_state_changed.subjects.discussing'.
